### PR TITLE
Update version of fastaq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='0.16.0',
+    version='0.16.1',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},
@@ -19,7 +19,7 @@ setup(
     tests_require=['nose >= 1.3'],
     install_requires=[
         'openpyxl',
-        'pyfastaq >= 3.6.0',
+        'pyfastaq >= 3.6.1',
         'pysam >= 0.8.1',
         'pymummer>=0.4.0',
         'bio_assembly_refinement>=0.3.3',


### PR DESCRIPTION
# Don't merge me (yet)

Fastaq now installs numpy via pip rather than apt-get installing it