### PR TITLE
Generalise get_dnaa; write versions etc info file

### DIFF
--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '0.16.1'
+version = '1.0.0'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/circlator/dnaa.py
+++ b/circlator/dnaa.py
@@ -5,7 +5,6 @@ import pyfastaq
 class Error (Exception): pass
 
 
-dna_re = re.compile('dnaa', re.IGNORECASE)
 genetic_code = 11
 aa_to_dna = {}
 for nucleotide, aa in pyfastaq.genetic_codes.codes[genetic_code].items():
@@ -13,13 +12,22 @@ for nucleotide, aa in pyfastaq.genetic_codes.codes[genetic_code].items():
 
 
 class UniprotDownloader:
-    def __init__(self, min_gene_length=333, max_gene_length=500):
+    def __init__(self, min_gene_length=333, max_gene_length=500, uniprot_search='dnaa', header_regex='dnaa', header_regex_ignorecase=True):
         self.min_gene_length = min_gene_length
         self.max_gene_length = max_gene_length
+        self.uniprot_search = re.sub('\s+', '+', uniprot_search.strip())
+        if header_regex_ignorecase:
+            self.header_regex = re.compile(header_regex, re.IGNORECASE)
+        else:
+            self.header_regex = re.compile(header_regex)
+
+
+    def _get_uniprot_url(self):
+        return 'http://www.uniprot.org/uniprot/?sort=score&desc=&compress=no&query=' + self.uniprot_search + '&force=no&format=fasta'
 
 
     def _download_from_uniprot(self, outfile):
-        pyfastaq.utils.syscall('wget -O ' + outfile + r''' "http://www.uniprot.org/uniprot/?sort=score&desc=&compress=no&query=dnaa&force=no&format=fasta"''')
+        pyfastaq.utils.syscall('wget -O ' + outfile + ' "' + self._get_uniprot_url() + '"')
 
 
     def _header_to_genus_species(self, header):
@@ -32,13 +40,17 @@ class UniprotDownloader:
         return tuple(genus_species)
 
 
+    def _header_matches_regex(self, sequence):
+        return self.header_regex.search(sequence.id) is not None
+
+
     def _check_sequence(self, sequence, seen_genus_species):
         if not(self.min_gene_length <= len(sequence) <= self.max_gene_length):
             return False, 'Too long or short'
         elif not sequence[0] == 'M':
             return False, 'Does not start with M'
-        elif dna_re.search(sequence.id) is None:
-            return False, 'No match to dnaA in name'
+        elif not self._header_matches_regex(sequence):
+            return False, 'No match to regex in name'
         else:
             genus_species = self._header_to_genus_species(sequence.id)
             if genus_species is None:

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -1,6 +1,8 @@
 import re
-from circlator import program
+import sys
+from circlator import program, common
 import shutil
+import pyfastaq
 
 class Error (Exception): pass
 
@@ -59,7 +61,7 @@ def handle_error(message, raise_error=True):
         print(message)
 
 
-def make_and_check_prog(name, verbose=False, raise_error=True):
+def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
     builder = prog_builders.get(name, program.Program)
     p = builder(
         prog_name_to_default[name],
@@ -85,9 +87,16 @@ def make_and_check_prog(name, verbose=False, raise_error=True):
     if verbose:
         print('Using', name, 'version', p.version())
 
+    if filehandle:
+        print('Using', name, 'version', p.version(), file=filehandle)
+
     return p
 
 
-def check_all_progs(verbose=False, raise_error=False):
+def check_all_progs(verbose=False, raise_error=False, filehandle=None):
+    if filehandle is not None:
+        print(sys.argv[0], 'version', common.version, file=filehandle)
+
     for prog in sorted(prog_name_to_default):
-        make_and_check_prog(prog, verbose=verbose, raise_error=raise_error)
+        make_and_check_prog(prog, verbose=verbose, raise_error=raise_error, filehandle=filehandle)
+

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -87,6 +87,10 @@ def run():
 
     os.chdir(options.outdir)
 
+    with open('00.info.txt', 'w') as f:
+        print(sys.argv[0], 'all', ' '.join(sys.argv[1:]), file=f)
+        circlator.external_progs.check_all_progs(filehandle=f)
+
     original_assembly_renamed = '00.input_assembly.fasta'
     bam = '01.mapreads.bam'
     filtered_reads_prefix = '02.bam2reads'

--- a/circlator/tasks/get_dnaa.py
+++ b/circlator/tasks/get_dnaa.py
@@ -5,16 +5,23 @@ class Error (Exception): pass
 
 def run():
     parser = argparse.ArgumentParser(
-        description = 'Downloads and filters a file of dnaA genes from uniprot',
+        description = 'Downloads and filters a file of dnaA (or other) genes from uniprot',
         usage = 'circlator get_dnaa [options] <output prefix>')
-    parser.add_argument('--min_length', type=int, help='Minimum length in amino acids [%(default)s]', default=333)
-    parser.add_argument('--max_length', type=int, help='Maximum length in amino acids [%(default)s]', default=500)
+    parser.add_argument('--min_length', type=int, help='Minimum length in amino acids [%(default)s]', default=333, metavar='INT')
+    parser.add_argument('--max_length', type=int, help='Maximum length in amino acids [%(default)s]', default=500, metavar='INT')
+    parser.add_argument('--uniprot_search', help='Uniprot search term [%(default)s]', default='dnaa', metavar='STRING')
+    parser.add_argument('--name_re', help='Each sequence name must match this regular expression [%(default)s]', default='dnaa', metavar='STRING')
+    parser.add_argument('--name_re_case_sensitive', action='store_true', help='Do a case-sensitive match to regular expression given by --name_re. Default is to ignore case.')
+
     parser.add_argument('outprefix', help='Prefix of output files', metavar='output prefix')
     options = parser.parse_args()
 
     dna_getter = circlator.dnaa.UniprotDownloader(
         min_gene_length=options.min_length,
-        max_gene_length=options.max_length
+        max_gene_length=options.max_length,
+        uniprot_search=options.uniprot_search,
+        header_regex=options.name_re,
+        header_regex_ignorecase=(not options.name_re_case_sensitive)
     )
 
     dna_getter.run(options.outprefix)

--- a/circlator/tests/dnaa_test.py
+++ b/circlator/tests/dnaa_test.py
@@ -19,6 +19,36 @@ class TestDnaa(unittest.TestCase):
         self.assertEqual(downloader._header_to_genus_species(bad_header), None)
 
 
+    def test_get_uniprot_url(self):
+        '''test _get_uniprot_url'''
+        tests = [
+            ('dnaa', 'http://www.uniprot.org/uniprot/?sort=score&desc=&compress=no&query=dnaa&force=no&format=fasta'),
+            ('spam eggs', 'http://www.uniprot.org/uniprot/?sort=score&desc=&compress=no&query=spam+eggs&force=no&format=fasta'),
+            ('  blue yellow   green  ', 'http://www.uniprot.org/uniprot/?sort=score&desc=&compress=no&query=blue+yellow+green&force=no&format=fasta'),
+        ]
+
+        for search_term, expected in tests:
+            downloader = dnaa.UniprotDownloader(uniprot_search=search_term)
+            self.assertEqual(downloader._get_uniprot_url(), expected)
+
+
+    def test_header_matches_regex(self):
+        '''test _header_matches_regex'''
+        tests = [
+            ('dnaa', 'foo dnaa spam eggs', True, True),
+            ('Dnaa', 'foo dnaa spam eggs', True, True),
+            ('Dnaa', 'foo dnaa spam eggs', False, False),
+            ('dnaa', 'foo DNAA spam eggs', True, True),
+            ('dnaa', 'foo spam eggs', True, False),
+            ('SPAM', 'foo spam eggs', True, True),
+        ]
+
+        for regex, sequence_name, ignorecase, expected in tests:
+            downloader = dnaa.UniprotDownloader(header_regex=regex, header_regex_ignorecase=ignorecase)
+            seq = pyfastaq.sequences.Fasta(sequence_name, 'ACGT')
+            self.assertEqual(downloader._header_matches_regex(seq), expected)
+
+
     def test_check_sequence(self):
         '''test _check_sequence'''
         downloader = dnaa.UniprotDownloader(min_gene_length=3, max_gene_length=6)
@@ -32,7 +62,7 @@ class TestDnaa(unittest.TestCase):
             (pyfastaq.sequences.Fasta('dnaa OS=genus3 species1 foo', 'MA'), (False, 'Too long or short')),
             (pyfastaq.sequences.Fasta('dnaa OS=genus3 species2 foo', 'MABCDEF'), (False, 'Too long or short')),
             (pyfastaq.sequences.Fasta('dnaa OS=genus3 species3 foo', 'XABC'), (False, 'Does not start with M')),
-            (pyfastaq.sequences.Fasta('x OS=genus3 species4 foo', 'MABC'), (False, 'No match to dnaA in name')),
+            (pyfastaq.sequences.Fasta('x OS=genus3 species4 foo', 'MABC'), (False, 'No match to regex in name')),
             (pyfastaq.sequences.Fasta('dnaa foo', 'MABC'), (False, 'Error getting genus species')),
             (pyfastaq.sequences.Fasta('dnaa OS=genus1 species1 foo', 'MABC'), (False, "Duplicate genus species ('genus1', 'species1')")),
         ]

--- a/scripts/circlator
+++ b/scripts/circlator
@@ -13,7 +13,7 @@ tasks = {
     'clean': 'Remove small and completely contained contigs from assembly',
     'fixstart': 'Change start position of circular sequences',
     'minimus2': 'Run the minimus2 based circularisation pipeline',
-    'get_dnaa': 'Download file of dnaA genes',
+    'get_dnaa': 'Download file of dnaA (or other of user\'s choice) genes',
     'version': 'Print version and exit',
 }
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='0.16.1',
+    version='1.0.0',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},


### PR DESCRIPTION
Two changes:

1. Generalise get_dnaa, so that user can give their own Uniprot search term. A few other options added related to generalising filtering the hits from uniprot.

2. When the whole pipeline is run, now writes a file called 00.info.txt that has how circlator was run, and versions of circlator and all its dependencies.