### PR TITLE
Progcheck report full paths

### DIFF
--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '1.0.0'
+version = '1.0.1'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -85,10 +85,10 @@ def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
         return p
 
     if verbose:
-        print('Using', name, 'version', p.version())
+        print('Using', name, 'version', p.version(), 'as', p.full_path)
 
     if filehandle:
-        print('Using', name, 'version', p.version(), file=filehandle)
+        print('Using', name, 'version', p.version(), 'as', p.full_path, file=filehandle)
 
     return p
 

--- a/circlator/program.py
+++ b/circlator/program.py
@@ -17,6 +17,7 @@ class Program:
 
         self.version_cmd = version_cmd
         self.version_regex = version_regex
+        self.full_path = shutil.which(self.path)
 
 
     def in_path(self):
@@ -43,7 +44,7 @@ class Program:
         v = self.version()
         if v is None:
             return None
-        return LooseVersion(v) >= LooseVersion(min_version) 
+        return LooseVersion(v) >= LooseVersion(min_version)
 
 
     def exe(self):

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -60,7 +60,7 @@ def run():
     options = parser.parse_args()
 
     print_message('{:_^79}'.format(' Checking external programs '), options)
-    circlator.external_progs.check_all_progs(verbose=options.verbose)
+    circlator.external_progs.check_all_progs(verbose=options.verbose, raise_error=True)
 
     files_to_check = [options.assembly, options.reads]
     if options.b2r_only_contigs:
@@ -89,7 +89,7 @@ def run():
 
     with open('00.info.txt', 'w') as f:
         print(sys.argv[0], 'all', ' '.join(sys.argv[1:]), file=f)
-        circlator.external_progs.check_all_progs(filehandle=f)
+        circlator.external_progs.check_all_progs(filehandle=f, raise_error=True)
 
     original_assembly_renamed = '00.input_assembly.fasta'
     bam = '01.mapreads.bam'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='1.0.0',
+    version='1.0.1',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},


### PR DESCRIPTION
This is for issue #36: https://github.com/sanger-pathogens/circlator/issues/36

This PR does that change. 

It also now dies when running the full pipeline if there is a problem with any of the dependencies not found (before, it would print and error to stderr and carry on).