### PR TITLE
Spades try all kmers

### DIFF
--- a/circlator/assemble.py
+++ b/circlator/assemble.py
@@ -14,6 +14,7 @@ class Assembler:
       threads=1,
       spades_kmers=None,
       verbose=False,
+      spades_use_first_success=False,
     ):
         self.outdir = os.path.abspath(outdir)
         self.reads = os.path.abspath(reads)
@@ -24,13 +25,14 @@ class Assembler:
         self.threads = threads
         self.spades = external_progs.make_and_check_prog('spades', verbose=self.verbose)
         self.spades_kmers = self._build_spades_kmers(spades_kmers)
+        self.spades_use_first_success = spades_use_first_success
         self.samtools = external_progs.make_and_check_prog('samtools', verbose=self.verbose)
         self.assembler = 'spades'
 
 
     def _build_spades_kmers(self, kmers):
         if kmers is None:
-            return [127,121,111,101,95,91,85,81,75,71]
+            return [127,117,107,97,87,77]
         elif type(kmers) == str:
             try:
                 kmer_list = [int(k) for k in kmers.split(',')]
@@ -105,6 +107,6 @@ class Assembler:
 
     def run(self):
         if self.assembler == 'spades':
-            self.run_spades()
+            self.run_spades(stop_at_first_success=self.spades_use_first_success)
         else:
             raise Error('Unknown assembler: "' + self.assembler + '". cannot continue')

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -32,7 +32,8 @@ def run():
     bam2reads_group.add_argument('--b2r_min_read_length', type=int, help='Minimum length of read to output [%(default)s]', default=250, metavar='INT')
 
     assemble_group = parser.add_argument_group('assemble options')
-    assemble_group.add_argument('--assemble_spades_k', help='Comma separated list of kmers to use when running SPAdes. Max kmer is 127 and each kmer should be an odd integer [%(default)s]', default='127,121,111,101,95,91,85,81,75,71', metavar='k1,k2,k3,...')
+    parser.add_argument('--assemble_spades_k', help='Comma separated list of kmers to use when running SPAdes. Max kmer is 127 and each kmer should be an odd integer [%(default)s]', default='127,117,107,97,87,77', metavar='k1,k2,k3,...')
+    parser.add_argument('--assemble_spades_use_first', action='store_true', help='Use the first successful SPAdes assembly. Default is to try all kmers and use the assembly with the largest N50')
 
     merge_group = parser.add_argument_group('merge options')
     merge_group.add_argument('--merge_diagdiff', type=int, help='Nucmer diagdiff option [%(default)s]', metavar='INT', default=25)
@@ -143,6 +144,7 @@ def run():
         assembly_dir,
         threads=options.threads,
         spades_kmers=options.assemble_spades_k,
+        spades_use_first_success=options.assemble_spades_use_first,
         verbose=options.verbose
     )
     a.run()

--- a/circlator/tasks/assemble.py
+++ b/circlator/tasks/assemble.py
@@ -9,7 +9,8 @@ def run():
         usage = 'circlator assemble [options] <in.reads.fasta> <out_dir>')
     parser.add_argument('--threads', type=int, help='Number of threads [%(default)s]', default=1, metavar='INT')
     parser.add_argument('--verbose', action='store_true', help='Be verbose')
-    parser.add_argument('--spades_k', help='Comma separated list of kmers to use when running SPAdes. Max kmer is 127 and each kmer should be an odd integer [%(default)s]', default='127,121,111,101,95,91,85,81,75,71', metavar='k1,k2,k3,...')
+    parser.add_argument('--spades_k', help='Comma separated list of kmers to use when running SPAdes. Max kmer is 127 and each kmer should be an odd integer [%(default)s]', default='127,117,107,97,87,77', metavar='k1,k2,k3,...')
+    parser.add_argument('--spades_use_first', action='store_true', help='Use the first successful SPAdes assembly. Default is to try all kmers and use the assembly with the largest N50')
     parser.add_argument('reads', help='Name of input reads FASTA file', metavar='in.reads.fasta')
     parser.add_argument('out_dir', help='Output directory (must not already exist)')
     options = parser.parse_args()
@@ -19,6 +20,7 @@ def run():
         options.out_dir,
         threads=options.threads,
         spades_kmers=options.spades_k,
+        spades_use_first_success=options.spades_use_first,
         verbose=options.verbose
     )
     a.run()

--- a/circlator/tests/assemble_test.py
+++ b/circlator/tests/assemble_test.py
@@ -38,6 +38,3 @@ class TestAssemble(unittest.TestCase):
         with self.assertRaises(assemble.Error):
             self.assembler._build_spades_kmers('41,spam')
 
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp_assemble_dir)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     tests_require=['nose >= 1.3'],
     install_requires=[
         'openpyxl',
-        'pyfastaq >= 3.6.1',
+        'pyfastaq >= 3.8.0',
         'pysam >= 0.8.1',
         'pymummer>=0.4.0',
         'bio_assembly_refinement>=0.3.3',


### PR DESCRIPTION
Previously, Circlator ran SPAdes with a list of kmers, longest first. Circlator would stop at the first assembly that was successful (ie error code==0). This PR changes the default behaviour to try all kmers, and choose the assembly with the best N50 (this is not always the one with  the biggest kmer). Also added an option to use the old behaviour.