### PR TITLE
Spades 3.6.1

### DIFF
--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '1.1.0'
+version = '1.1.1'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -60,7 +60,7 @@ prog_builders = {
 
 def handle_error(message, raise_error=True):
     if raise_error:
-        raise Error(message + ' Cannot continue')
+        raise Error(message + '\nCannot continue')
     else:
         print(message)
 
@@ -88,9 +88,16 @@ def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
         handle_error('Version of ' + name + ' too low. I found ' + p.version() + ', but must be at least ' + min_versions[name] + '. Found here:\n' + p.full_path, raise_error=raise_error)
         return p
 
-    if name in max_versions and not p.version_at_most(max_versions[name]):
+    if name != 'spades' and name in max_versions and not p.version_at_most(max_versions[name]):
         handle_error('Version of ' + name + ' too high. I found ' + p.version() + ', but must be at most ' + max_versions[name] + '. Found here:\n' + p.full_path, raise_error=raise_error)
         return p
+
+    if name == 'spades' and not p.version_at_most(max_versions['spades']):
+        print('WARNING: SPAdes version', p.version(), 'found, which is newer than 3.6.0.', file=sys.stderr)
+        print('         Circlator can use this version, but some circularizations may be missed.', file=sys.stderr)
+        print('         We recommend that you use version 3.6.0, which is available for Linux using:', file=sys.stderr)
+        print('         wget http://spades.bioinf.spbau.ru/release3.6.0/SPAdes-3.6.0-Linux.tar.gz', file=sys.stderr)
+
 
     if verbose:
         print('Using', name, 'version', p.version(), 'as', p.full_path)

--- a/circlator/merge.py
+++ b/circlator/merge.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import copy
 import shutil
 import collections
@@ -339,7 +340,22 @@ class Merger:
         used_spades_contigs = set()
         reassembly_fastg = self.reassembly_fasta[:-1] + 'g'
 
-        called_as_circular_by_spades = self._get_spades_circular_nodes(reassembly_fastg)
+        if os.path.exists(reassembly_fastg):
+            called_as_circular_by_spades = self._get_spades_circular_nodes(reassembly_fastg)
+        else:
+            called_as_circular_by_spades = set()
+            warning_lines = [
+                'WARNING: FASTG reassembly file ' + reassembly_fastg + ' not found. If the reassembly was not made with SPAdes, this is normal (but you miss out on the extra information that SPAdes can output).',
+                'WARNING:  ... If the reassembly was made with SPAdes, then please consider using version 3.6.0 of SPAdes, which does make this file.',
+                'WARNING:  ... SPAdes 3.6.0 can be obtained for Linux like this:',
+                'WARNING:  ... wget http://spades.bioinf.spbau.ru/release3.6.0/SPAdes-3.6.0-Linux.tar.gz',
+            ]
+            for line in warning_lines:
+                print(log_outprefix, line, sep='\t', file=log_fh)
+                print(log_outprefix, line, sep='\t', file=sys.stderr)
+
+            print(log_outprefix, 'WARNING:  ... this message has also been written to the circularise_details.log file.', sep='\t', file=sys.stderr)
+
         if len(called_as_circular_by_spades):
             circular_string = ','.join(sorted(called_as_circular_by_spades))
         else:

--- a/circlator/merge.py
+++ b/circlator/merge.py
@@ -820,7 +820,7 @@ class Merger:
 
         if nucmer_coords_file is None:
             self._run_nucmer(self.original_fasta, self.reassembly_fasta, nucmer_circularise_coords)
-            self._write_act_files(self.original_fasta, self.reassembly_fasta, nucmer_circularise_coords, self.outprefix + '.circularise.')
+            self._write_act_files(self.original_fasta, self.reassembly_fasta, nucmer_circularise_coords, self.outprefix + '.circularise')
         else:
             os.symlink(nucmer_coords_file, nucmer_circularise_coords)
             os.symlink(act_script, self.outprefix + '.circularise.start_act.sh')

--- a/circlator/merge.py
+++ b/circlator/merge.py
@@ -723,7 +723,10 @@ class Merger:
                 )
                 a.run()
                 os.rename(os.path.join(assembler_dir, 'contigs.fasta'), reassembly_fasta)
-                os.rename(os.path.join(assembler_dir, 'contigs.fastg'), reassembly_fastg)
+                contigs_fastg = os.path.join(assembler_dir, 'contigs.fastg')
+                if os.path.exists(contigs_fastg):
+                    os.rename(contigs_fastg, reassembly_fastg)
+
                 shutil.rmtree(assembler_dir)
                 pyfastaq.tasks.file_to_dict(reassembly_fasta, self.reassembly_contigs)
             elif iteration <= 2:

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -165,7 +165,6 @@ def run():
         merge_reads = filtered_reads
     else:
         merge_reads = None
-        options.merge_opts.extend(['--reads', filtered_reads])
 
     m = circlator.merge.Merger(
         assembly_to_use,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='1.1.0',
+    version='1.1.1',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},


### PR DESCRIPTION
This is to handle if spades version is >3.6.0.

Circlator can still use >3.6.0, but with reduced functionality. So output lots of user warnings that they may wish to use 3.6.0 instead.