### PR TITLE
Bug running merge (issue 44)

### DIFF
--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '1.1.2'
+version = '1.1.3'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/circlator/merge.py
+++ b/circlator/merge.py
@@ -649,7 +649,9 @@ class Merger:
     def _iterative_bridged_contig_pair_merge(self, outprefix):
         '''Iteratively merges contig pairs using bridging contigs from reassembly, until no more can be merged'''
         if self.reads is None:
-            return self.original_fasta, self.reassembly, None, None
+            if self.verbose:
+                print('Skipping iterative contig merging because no reads given (see --reads option)')
+            return self.original_fasta, None, None
 
         log_file = outprefix + '.iterations.log'
         log_fh = pyfastaq.utils.open_file_write(log_file)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='1.1.2',
+    version='1.1.3',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},


### PR DESCRIPTION
Circlator was crashing when the 'merge' tasl was run directly (as opposed to as part of the whole pipeline). This PR fixes that bug. Was reported in issue #44.