### PR TITLE
Make usage clearer

### DIFF
--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -55,8 +55,8 @@ def run():
     clean_group.add_argument('--clean_breaklen', type=int, help='breaklen option used by nucmer [%(default)s]', metavar='INT', default=500)
 
     fixstart_group = parser.add_argument_group('fixstart options')
-    fixstart_group.add_argument('--genes_fa', help='FASTA file of genes to search for to use as start point', metavar='FILENAME')
-    fixstart_group.add_argument('--fixstart_min_id', type=float, help='Minimum percent identity of promer match to dnaA gene [%(default)s]', default=70, metavar='FLOAT')
+    fixstart_group.add_argument('--genes_fa', help='FASTA file of genes to search for to use as start point. If this option is not used, a built-in set of dnaA genes is used', metavar='FILENAME')
+    fixstart_group.add_argument('--fixstart_min_id', type=float, help='Minimum percent identity of promer match between contigs and gene(s) to use as start point [%(default)s]', default=70, metavar='FLOAT')
 
     options = parser.parse_args()
 

--- a/circlator/tasks/fixstart.py
+++ b/circlator/tasks/fixstart.py
@@ -5,9 +5,9 @@ def run():
     parser = argparse.ArgumentParser(
         description = 'Change start point of each sequence in assembly',
         usage = 'circlator fixstart [options] <assembly.fasta> <outprefix>')
-    parser.add_argument('--genes_fa', help='FASTA file of genes to search for to use as start point', metavar='FILENAME')
+    parser.add_argument('--genes_fa', help='FASTA file of genes to search for to use as start point. If this option is not used, a built-in set of dnaA genes is used', metavar='FILENAME')
     parser.add_argument('--ignore', help='Absolute path to file of IDs of contigs to not change', metavar='FILENAME')
-    parser.add_argument('--min_id', type=float, help='Minimum percent identity of promer match to dnaA gene [%(default)s]', default=70, metavar='FLOAT')
+    parser.add_argument('--min_id', type=float, help='Minimum percent identity of promer match between contigs and gene(s) to use as start point [%(default)s]', default=70, metavar='FLOAT')
     parser.add_argument('assembly_fa', help='Name of input FASTA file', metavar='assembly.fasta')
     parser.add_argument('outprefix', help='Prefix of output files')
     options = parser.parse_args()


### PR DESCRIPTION
Just a little tweak to the usage: be clearer that the min_id applies to any reference genes, including when --genes_fa is used.