### PR TITLE
Nucmer simplify true

### DIFF
--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '1.1.3'
+version = '1.1.4'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/circlator/merge.py
+++ b/circlator/merge.py
@@ -67,7 +67,7 @@ class Merger:
             diagdiff=self.nucmer_diagdiff,
             maxmatch=True,
             breaklen=self.nucmer_breaklen,
-            simplify=False,
+            simplify=True,
             verbose=self.verbose
         )
         n.run()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='circlator',
-    version='1.1.3',
+    version='1.1.4',
     description='circlator: a tool to circularise genome assemblies',
     packages = find_packages(),
     package_data={'circlator': ['data/*']},
@@ -22,7 +22,7 @@ setup(
         'pyfastaq >= 3.10.0',
         'pysam >= 0.8.1',
         'pymummer>=0.6.1',
-        'bio_assembly_refinement>=0.4.0',
+        'bio_assembly_refinement>=0.5.0',
     ],
     license='GPLv3',
     classifiers=[


### PR DESCRIPTION
Stop using the --nosimplfy option with nucmer, as it can cause multiple near-identical hits, and stop merge from working.