### PR TITLE
support for samtools > 1.2

### DIFF
--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -108,4 +108,3 @@ def check_all_progs(verbose=False, raise_error=False, filehandle=None):
 
     for prog in sorted(prog_name_to_default):
         make_and_check_prog(prog, verbose=verbose, raise_error=raise_error, filehandle=filehandle)
-

--- a/circlator/mapping.py
+++ b/circlator/mapping.py
@@ -83,13 +83,16 @@ def bwa_mem(
 
     if samtools.version_at_least('1.2'):
         outparam = '-o'
+        samout = outfile
+    else:
+        samout = outfile[:-4]
 
     cmd = ' '.join([
         samtools.exe(), 'sort',
         '-@', str(threads),
         '-m', str(thread_mem) + 'M',
         unsorted_bam,
-        outparam,outfile[:-4]
+        outparam,samout
     ])
 
     common.syscall(cmd, verbose=verbose)

--- a/circlator/mapping.py
+++ b/circlator/mapping.py
@@ -16,7 +16,7 @@ index_extensions = [
 
 
 def bwa_index(infile, outprefix=None, bwa='bwa', verbose=False):
-    if outprefix is None: 
+    if outprefix is None:
         outprefix = infile
 
     missing = [not os.path.exists(outprefix + '.' + x) for x in index_extensions]
@@ -60,7 +60,7 @@ def bwa_mem(
         bwa_options,
         '-t', str(threads),
         tmp_index,
-        reads, 
+        reads,
         '|',
         samtools.exe(), 'view',
         '-F 0x0800',
@@ -74,15 +74,24 @@ def bwa_mem(
     bwa_index_clean(tmp_index)
     threads = min(4, threads)
     thread_mem = int(500 / threads)
-    
+
+    # here we have to check for the version of samtools, starting from 1.3 the
+    # -o flag is used for specifying the samtools sort output-file
+    # Starting from 1.2 you can use the -o flag
+
+    outparam = ''
+
+    if p.version_at_least('1.2'):
+        outparam = '-o'
+
     cmd = ' '.join([
         samtools.exe(), 'sort',
         '-@', str(threads),
         '-m', str(thread_mem) + 'M',
         unsorted_bam,
-        outfile[:-4]
+        outparam,outfile[:-4]
     ])
- 
+
     common.syscall(cmd, verbose=verbose)
     os.unlink(unsorted_bam)
 

--- a/circlator/mapping.py
+++ b/circlator/mapping.py
@@ -81,7 +81,7 @@ def bwa_mem(
 
     outparam = ''
 
-    if p.version_at_least('1.2'):
+    if samtools.version_at_least('1.2'):
         outparam = '-o'
 
     cmd = ' '.join([


### PR DESCRIPTION
When running circlator with `samtools` 1.3 the mapping step failed due to the error below. This is because starting from `samtools` 1.3 you have to specify the `-o` option for the output-file, otherwise it will not run. You can already start using this parameter from version 1.2 on. 

As an easy workaround I now just checked for the version of samtools before running the sort-step and either run it with or without the `-o` flag. 

```
The following command failed with exit code 1
samtools sort -@ 1 -m 500M 01.mapreads.bam.tmp.unsorted.bam 01.mapreads

The output was:

[bam_sort] Use -T PREFIX / -o FILE to specify temporary and final output files
Usage: samtools sort [options...] [in.bam]
Options:
  -l INT     Set compression level, from 0 (uncompressed) to 9 (best)
  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]
  -n         Sort by read name
  -o FILE    Write final output to FILE rather than standard output
  -T PREFIX  Write temporary files to PREFIX.nnnn.bam
  -@, --threads INT
             Set number of sorting and compression threads [1]
      --input-fmt-option OPT[=VAL]
               Specify a single input file format option in the form
               of OPTION or OPTION=VALUE
  -O, --output-fmt FORMAT[,OPT[=VAL]]...
               Specify output format (SAM, BAM, CRAM)
      --output-fmt-option OPT[=VAL]
               Specify a single output file format option in the form
               of OPTION or OPTION=VALUE
      --reference FILE
               Reference sequence FASTA FILE [null]
```