### PR TITLE
add verbose option

### DIFF
--- a/circlator/tasks/bam2reads.py
+++ b/circlator/tasks/bam2reads.py
@@ -11,6 +11,7 @@ def run():
     parser.add_argument('--only_contigs', help='File of contig names (one per line). Only reads that map to these contigs are kept (and unmapped reads, unless --discard_unmapped is used).', metavar='FILENAME')
     parser.add_argument('--length_cutoff', type=int, help='All reads mapped to contigs shorter than this will be kept [%(default)s]', default=100000, metavar='INT')
     parser.add_argument('--min_read_length', type=int, help='Minimum length of read to output [%(default)s]', default=250, metavar='INT')
+    parser.add_argument('--verbose', action='store_true', help='Be verbose')
     parser.add_argument('bam', help='Name of input bam file', metavar='in.bam')
     parser.add_argument('outprefix', help='Prefix of output filenames')
     options = parser.parse_args()
@@ -22,6 +23,7 @@ def run():
         min_read_length=options.min_read_length,
         contigs_to_use=options.only_contigs,
         discard_unmapped=options.discard_unmapped,
+        verbose=options.verbose,
     )
     bam_filter.run()
 


### PR DESCRIPTION
See issue #57 . This adds verbose option to bam2reads. Just leaves fixstart, which uses bio_assembly_refinement, without a verbose option. No point adding it now, as soon it will all be refactored so that bio_assembly_refinement is no longer a dependency.