### PR TITLE
Version reporting improvements

### DIFF
--- a/circlator/__init__.py
+++ b/circlator/__init__.py
@@ -1,3 +1,11 @@
+from pkg_resources import get_distribution
+
+try:
+    __version__ = get_distribution('circlator').version
+except:
+    __version__ = 'local'
+
+
 __all__ = [
     'assemble',
     'assembly',
@@ -12,6 +20,7 @@ __all__ = [
     'minimus2',
     'program',
     'tasks',
+    'versions',
 ]
 
 from circlator import *

--- a/circlator/common.py
+++ b/circlator/common.py
@@ -4,8 +4,6 @@ import subprocess
 
 class Error (Exception): pass
 
-version = '1.2.0'
-
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:
         print('syscall:', cmd, flush=True)

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -27,7 +27,7 @@ prog_to_version_cmd = {
     'nucmer': ('--version', re.compile('^NUCmer \(NUCleotide MUMmer\) version ([0-9\.]+)')),
     'prodigal': ('-v', re.compile('^Prodigal V([0-9\.]+):')),
     'samtools': ('', re.compile('^Version: ([0-9\.]+)')),
-    'spades': ('', re.compile('^SPAdes genome assembler v.([0-9\.]+)')),
+    'spades': ('', re.compile('^SPAdes genome assembler v.?([0-9][0-9\.]+)')),
 }
 
 

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -1,6 +1,7 @@
 import re
 import sys
 from circlator import program, common
+from circlator import __version__ as circlator_version
 import shutil
 import pyfastaq
 
@@ -94,17 +95,14 @@ def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
         return p
 
     if verbose:
-        print('Using', name, 'version', p.version(), 'as', p.full_path)
+        print(name, p.version(), p.full_path, sep='\t')
 
     if filehandle:
-        print('Using', name, 'version', p.version(), 'as', p.full_path, file=filehandle)
+        print(name, p.version(), p.full_path, sep='\t', file=filehandle)
 
     return p
 
 
 def check_all_progs(verbose=False, raise_error=False, filehandle=None):
-    if filehandle is not None:
-        print(sys.argv[0], 'version', common.version, file=filehandle)
-
     for prog in sorted(prog_name_to_default):
         make_and_check_prog(prog, verbose=verbose, raise_error=raise_error, filehandle=filehandle)

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -63,7 +63,7 @@ def run():
     options = parser.parse_args()
 
     print_message('{:_^79}'.format(' Checking external programs '), options)
-    circlator.external_progs.check_all_progs(verbose=options.verbose, raise_error=True)
+    circlator.versions.get_all_versions(sys.stdout)
 
     files_to_check = [options.assembly, options.reads]
     if options.b2r_only_contigs:
@@ -92,7 +92,7 @@ def run():
 
     with open('00.info.txt', 'w') as f:
         print(sys.argv[0], 'all', ' '.join(sys.argv[1:]), file=f)
-        circlator.external_progs.check_all_progs(filehandle=f, raise_error=True)
+        circlator.versions.get_all_versions(f)
 
     original_assembly_renamed = '00.input_assembly.fasta'
     bam = '01.mapreads.bam'

--- a/circlator/tasks/progcheck.py
+++ b/circlator/tasks/progcheck.py
@@ -1,11 +1,10 @@
 import argparse
 import sys
-from circlator import external_progs
+from circlator import versions
 
 def run():
     parser = argparse.ArgumentParser(
         description = 'Checks all dependencies are found and are correct versions',
         usage = 'circlator progcheck')
     options = parser.parse_args()
-
-    external_progs.check_all_progs(verbose=True, raise_error=False)
+    versions.get_all_versions(sys.stdout)

--- a/circlator/versions.py
+++ b/circlator/versions.py
@@ -1,0 +1,30 @@
+import sys
+import bio_assembly_refinement
+import openpyxl
+import pyfastaq
+import pymummer
+import pysam
+from circlator import external_progs, __version__
+from circlator import __version__ as circlator_version
+
+
+def get_all_versions(filehandle):
+    print('Circlator version:', circlator_version, file=filehandle)
+
+    print('\nExternal dependencies:', file=filehandle)
+    external_progs.check_all_progs(verbose=False, raise_error=False, filehandle=filehandle)
+
+    print('\nPython version:', file=filehandle)
+    print(sys.version, file=filehandle)
+
+    print('\nPython dependencies:', file=filehandle)
+    for module in ['bio_assembly_refinement', 'openpyxl', 'pyfastaq', 'pymummer', 'pysam']:
+        try:
+            version = eval(module + '.__version__')
+            path = eval(module + '.__file__')
+        except:
+            version = 'NOT_FOUND'
+            path = 'NOT_FOUND'
+
+        print(module + '\t' + version + '\t' + path, file=filehandle)
+

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
     tests_require=['nose >= 1.3'],
     install_requires=[
         'openpyxl',
-        'pyfastaq >= 3.10.0',
+        'pyfastaq >= 3.12.1',
         'pysam >= 0.8.1, <= 0.8.3',
-        'pymummer>=0.6.1',
-        'bio_assembly_refinement>=0.5.0',
+        'pymummer>=0.7.1',
+        'bio_assembly_refinement>=0.5.1',
     ],
     license='GPLv3',
     classifiers=[


### PR DESCRIPTION
This tidies up reporting versions:
- fixes bug reporting SPAdes version (see issue #56)
- now reports python version and the versions and paths of packages that circlator is using
- makes `circlator.__version__` work