### PR TITLE
Summarise circularizations

### DIFF
--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -140,6 +140,7 @@ def run():
         min_read_length=options.b2r_min_read_length,
         contigs_to_use=options.b2r_only_contigs,
         discard_unmapped=options.b2r_discard_unmapped,
+        verbose=options.verbose,
     )
     bam_filter.run()
 

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -64,7 +64,11 @@ def run():
     options = parser.parse_args()
 
     print_message('{:_^79}'.format(' Checking external programs '), options)
-    circlator.versions.get_all_versions(sys.stdout)
+    if options.verbose:
+        circlator.versions.get_all_versions(sys.stdout, raise_error=True)
+    else:
+        circlator.versions.get_all_versions(None, raise_error=True)
+
 
     files_to_check = [options.assembly, options.reads]
     if options.b2r_only_contigs:

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -248,5 +248,13 @@ def run():
     )
     fixer.run()
 
+    #-------------------------------- summary -------------------------------
+    print_message('{:_^79}'.format(' Summary '), options)
+    number_of_input_contigs = pyfastaq.tasks.count_sequences(original_assembly_renamed)
+    final_number_of_contigs = pyfastaq.tasks.count_sequences(fixstart_fasta)
+    print_message('Number of input contigs: ' + str(number_of_input_contigs), options)
+    print_message('Number of contigs after merging: ' + str(final_number_of_contigs), options)
+    print_message(' '.join(['Circularized', str(len(contigs_to_keep)), 'of', str(final_number_of_contigs), 'contig(s)']), options)
+
     with open(fixstart_prefix + '.ALL_FINISHED', 'w') as f:
         pass

--- a/circlator/tasks/all.py
+++ b/circlator/tasks/all.py
@@ -18,6 +18,7 @@ def run():
         usage = 'circlator all [options] <assembly.fasta> <reads.fasta> <output directory>')
     parser.add_argument('--threads', type=int, help='Number of threads [%(default)s]', default=1, metavar='INT')
     parser.add_argument('--verbose', action='store_true', help='Be verbose')
+    parser.add_argument('--unchanged_code', type=int, help='Code to return when the input assembly is not changed [%(default)s]', default=0, metavar='INT')
     parser.add_argument('assembly', help='Name of original assembly', metavar='assembly.fasta')
     parser.add_argument('reads', help='Name of corrected reads FASTA file', metavar='reads.fasta')
     parser.add_argument('outdir', help='Name of output directory (must not already exist)', metavar='output directory')
@@ -252,9 +253,14 @@ def run():
     print_message('{:_^79}'.format(' Summary '), options)
     number_of_input_contigs = pyfastaq.tasks.count_sequences(original_assembly_renamed)
     final_number_of_contigs = pyfastaq.tasks.count_sequences(fixstart_fasta)
+    number_circularized = len(contigs_to_keep)
     print_message('Number of input contigs: ' + str(number_of_input_contigs), options)
     print_message('Number of contigs after merging: ' + str(final_number_of_contigs), options)
-    print_message(' '.join(['Circularized', str(len(contigs_to_keep)), 'of', str(final_number_of_contigs), 'contig(s)']), options)
+    print_message(' '.join(['Circularized', str(number_circularized), 'of', str(final_number_of_contigs), 'contig(s)']), options)
 
     with open(fixstart_prefix + '.ALL_FINISHED', 'w') as f:
         pass
+
+    if number_of_input_contigs == final_number_of_contigs and number_circularized == 0:
+        sys.exit(options.unchanged_code)
+

--- a/circlator/tasks/progcheck.py
+++ b/circlator/tasks/progcheck.py
@@ -7,4 +7,4 @@ def run():
         description = 'Checks all dependencies are found and are correct versions',
         usage = 'circlator progcheck')
     options = parser.parse_args()
-    versions.get_all_versions(sys.stdout)
+    versions.get_all_versions(sys.stdout, raise_error=False)

--- a/circlator/versions.py
+++ b/circlator/versions.py
@@ -8,16 +8,20 @@ from circlator import external_progs, __version__
 from circlator import __version__ as circlator_version
 
 
-def get_all_versions(filehandle):
-    print('Circlator version:', circlator_version, file=filehandle)
+def get_all_versions(filehandle, raise_error=True):
+    if filehandle is not None:
+        print('Circlator version:', circlator_version, file=filehandle)
+        print('\nExternal dependencies:', file=filehandle)
 
-    print('\nExternal dependencies:', file=filehandle)
-    external_progs.check_all_progs(verbose=False, raise_error=False, filehandle=filehandle)
+    external_progs.check_all_progs(verbose=False, raise_error=raise_error, filehandle=filehandle)
 
-    print('\nPython version:', file=filehandle)
-    print(sys.version, file=filehandle)
+    if filehandle is not None:
+        print('\nPython version:', file=filehandle)
+        print(sys.version, file=filehandle)
+        print('\nPython dependencies:', file=filehandle)
 
-    print('\nPython dependencies:', file=filehandle)
+    found_bad_module = False
+
     for module in ['bio_assembly_refinement', 'openpyxl', 'pyfastaq', 'pymummer', 'pysam']:
         try:
             version = eval(module + '.__version__')
@@ -25,6 +29,12 @@ def get_all_versions(filehandle):
         except:
             version = 'NOT_FOUND'
             path = 'NOT_FOUND'
+            found_bad_module = True
 
-        print(module + '\t' + version + '\t' + path, file=filehandle)
+        if filehandle is not None:
+            print(module + '\t' + version + '\t' + path, file=filehandle)
+
+    if raise_error and found_bad_module:
+        print('Some dependencies not satisfied. Cannot continue. Try running: circlator progcheck', file=sys.stderr)
+        sys.exit(1)
 


### PR DESCRIPTION
- write final counts of contigs circularized etc (see issue #55)
- do not print versions when --verbose wasn't used with circlator all
- pass --verbose option to bam2reads when running circlator all
- add option --unchanged_code (see issue #55)