### PR TITLE
Bug fix running version task

### DIFF
--- a/circlator/tasks/version.py
+++ b/circlator/tasks/version.py
@@ -1,4 +1,5 @@
+from circlator import __version__ as circlator_version
 import circlator
 
 def run():
-    print(circlator.common.version)
+    print(circlator_version)


### PR DESCRIPTION
- missed changing the "version" task in earlier commit when implementing `circlator.__version__`. This fixes it so "circlator version" actually works