### PR TITLE
Spades python2 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ addons:
     packages:
     - zlib1g-dev
     - libncurses5-dev
-cache:
-  directories:
-  - "build"
-  - "$HOME/.cache/pip"
 python:
   - "3.4"
 sudo: false

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -76,8 +76,11 @@ def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
         return p
 
     if name == 'spades' and p.version() == bad_versions['spades']:
-        handle_error('ERROR! SPAdes version ' + bad_versions['spades'] + ' is incompatible with Circlator. Please update SPAdes to the latest version', raise_error=raise_error)
+        handle_error('ERROR! SPAdes version ' + bad_versions['spades'] + ' is incompatible with Circlator. Please use SPAdes 3.7.1', raise_error=raise_error)
         return p
+
+    if name == 'spades' and not p.version().startswith('3.7.'):
+        print('WARNING: SPAdes version', p.version(), 'is being used. It will work, but better results are usually obtained from Circlator using SPAdes version 3.7.1', file=sys.stderr)
 
     if verbose:
         print(name, p.version(), p.full_path, sep='\t')

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -8,15 +8,6 @@ import pyfastaq
 class Error (Exception): pass
 
 
-# Travis is using python3.4, and actually "python" in travis means
-# python3.4, not python2. SPAdes throws an error about not being
-# compatible with python3.4.
-# This means we need to explicitly run SPAdes with python2.
-class Spades(program.Program):
-    def exe(self):
-        return 'python2 ' + shutil.which(self.path)
-
-
 prog_to_env_var = {
     'samtools': 'CIRCLATOR_SAMTOOLS',
     'spades': 'CIRCLATOR_SPADES',
@@ -37,7 +28,7 @@ min_versions = {
     'nucmer': '3.1',
     'prodigal': '2.6',
     'samtools': '0.1.19',
-    'spades': '3.5.0',
+    'spades': '3.6.2', # this is the first version to support python3
 }
 
 
@@ -55,11 +46,6 @@ prog_name_to_default = {
 }
 
 
-prog_builders = {
-    'spades': Spades
-}
-
-
 def handle_error(message, raise_error=True):
     if raise_error:
         raise Error(message + '\nCannot continue')
@@ -68,8 +54,7 @@ def handle_error(message, raise_error=True):
 
 
 def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
-    builder = prog_builders.get(name, program.Program)
-    p = builder(
+    p = program.Program(
         prog_name_to_default[name],
         prog_to_version_cmd[name][0],
         prog_to_version_cmd[name][1],

--- a/circlator/external_progs.py
+++ b/circlator/external_progs.py
@@ -80,7 +80,7 @@ def make_and_check_prog(name, verbose=False, raise_error=True, filehandle=None):
         return p
 
     if name == 'spades' and not p.version().startswith('3.7.'):
-        print('WARNING: SPAdes version', p.version(), 'is being used. It will work, but better results are usually obtained from Circlator using SPAdes version 3.7.1', file=sys.stderr)
+        print('WARNING: SPAdes version', p.version(), 'is being used. It will work, but better results are usually obtained from Circlator using SPAdes version 3.7.1. Although 3.7.1 is not the latest version, we recommend it for Circlator.', file=sys.stderr)
 
     if verbose:
         print(name, p.version(), p.full_path, sep='\t')

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -8,7 +8,7 @@ BWA_VERSION=0.7.12
 PRODIGAL_VERSION=2.6.2
 SAMTOOLS_VERSION=1.3
 MUMMER_VERSION=3.23
-SPADES_VERSION=3.6.0
+SPADES_VERSION=3.7.1
 
 BWA_DOWNLOAD_URL="http://downloads.sourceforge.net/project/bio-bwa/bwa-${BWA_VERSION}.tar.bz2"
 PRODIGAL_DOWNLOAD_URL="https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'openpyxl',
         'pyfastaq >= 3.12.1',
-        'pysam >= 0.8.1, <= 0.8.3',
+        'pysam >= 0.8.1',
         'pymummer>=0.7.1',
     ],
     license='GPLv3',


### PR DESCRIPTION
SPAdes from 3.6.2 onwards is compatible with python3.

- require spades version >=3.6.2
- no longer run spades with "python2 spades.py', as just "spades.py" should work
- recommend spades 3.7.1 (worked the best on NCTC samples from Circlator paper).
