### PR TITLE
AMOS install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN   cd ${BUILD_DIR}/build && \
       cp src/Align/find-tandem.cc src/Align/find-tandem.cc.original && \
       echo '#include <getopt.h>' | cat - src/Align/find-tandem.cc.original > src/Align/find-tandem.cc && \
       make && make install && make clean
-      
+
 ENV   PATH="${BUILD_DIR}/build/amos-3.1.0/bin:${PATH}"
 RUN   export PATH
 RUN   ln -s ${BUILD_DIR}/build/MUMmer3.23/show-coords /usr/local/bin
 
-RUN   circlator progcheck
+RUN   circlator progcheck && circlator test /tmp/circlator-test && rm -r /tmp/circlator-test
 
 CMD   echo "Usage:  docker run -v \`pwd\`:/var/data -it <IMAGE_NAME> bash" && \
       echo "" && \

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose >= 1.3'],
     install_requires=[
-        'openpyxl',
+        'openpyxl == 2.6.4',
         'pyfastaq >= 3.12.1',
         'pysam >= 0.8.1',
         'pymummer>=0.9.0',


### PR DESCRIPTION
AMOS install to sup[port minimus2 pipeline
h/t Yuri Bendaña (ybendana) for working AMOS install -- see PR #151

Found openpyxl needed a downgrade to 2.6.4 to keep compatibility with circlator.

Also merged in some minor docker build tweaks.