### PR TITLE
split tests to allow for testing without spades installed

### DIFF
--- a/circlator/tests/assemble_test.py
+++ b/circlator/tests/assemble_test.py
@@ -9,7 +9,7 @@ modules_dir = os.path.dirname(os.path.abspath(assemble.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
 
 
-class TestAssemble(unittest.TestCase):
+class TestAssembleSpades(unittest.TestCase):
     def setUp(self):
         self.tmp_assemble_dir = 'tmp.assemble_test'
         self.assembler = assemble.Assembler(
@@ -60,6 +60,11 @@ class TestAssemble(unittest.TestCase):
 
         self.assembler.threads = 2
         self.assertEqual(cmd_start + ' -o out -t 2 -k 41 --careful --only-assembler', self.assembler._make_spades_command(41, 'out'))
+
+
+class TestAssembleCanu(unittest.TestCase):
+    def setUp(self):
+        self.tmp_assemble_dir = 'tmp.assemble_test'
 
 
     def test_make_canu_command(self):

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ setup(
     author_email='path-help@sanger.ac.uk',
     url='https://github.com/sanger-pathogens/circlator',
     scripts=glob.glob('scripts/*'),
-    test_suite='nose.collector',
-    tests_require=['nose >= 1.3'],
+    tests_require=['pytest'],
     install_requires=[
         'openpyxl == 2.6.4',
         'pyfastaq >= 3.12.1',


### PR DESCRIPTION
- Allow for testing without spades installed
- Switch from nose->pytest since the former is deprecated
