### PR TITLE
Update assemble.py

### DIFF
--- a/circlator/assemble.py
+++ b/circlator/assemble.py
@@ -83,7 +83,6 @@ class Assembler:
         cmd = [
             self.canu.exe(),
             '-useGrid=false',
-            'gnuplotTested=true',
             '-assemble',
             'genomeSize='+str(float(self.genomeSize)/1000000)+'m',
             '-d', outdir,


### PR DESCRIPTION
The option `gnuplotTested=true` is no longer valid on latest versions of canu, as noted by @ilnamkang